### PR TITLE
Allow omitting IPAM configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Remove the binary and temporary files generated whild building the source codes.
 * `type` (string, required): "vhostuser"
 * `if0name` (string, required): name of the virtual interface
 * `vhost` (dictionary, required): Vhostuser configurations.
-* `ipam` (dictionary, required): IPAM configuration to be used for this network.
+* `ipam` (dictionary, optional): IPAM configuration to be used for this network.
 
 ## Usage
 


### PR DESCRIPTION
Change IPAM dictionary from mandatory to optional configuration, similarly than in [sriov-cni](https://github.com/Intel-Corp/sriov-cni), because there are many use cases where IPAM is not needed.