### PR TITLE
Add usage example with 2 vhostuser ports and DPDK testpmd as application

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,9 +4,7 @@
 
 - DPDK Vhostuser is new virtualization technology. Please refer to [here](http://dpdk.org/doc/guides/howto/virtio_user_for_container_networking.html) for more information.
 
-<p align="center">
-   <img src="doc/images/Vhostuser-plugin.png" width="1008" />
-</p>
+![Vhostuser plugin](doc/images/Vhostuser-plugin.png)
 
 ## Build & Clean
 
@@ -72,9 +70,8 @@ Refer Multus (NFV based Multi - Network plugin), DPDK-SRIOV CNI plugins
 Encourage the users/developers to use Multus based Kubernetes CDR/TPR based network objects. Please follow the configuration details in the link: [Usage with Kubernetes CRD/TPR based Network Objects](https://github.com/Intel-Corp/multus-cni/blob/master/README.md#usage-with-kubernetes-crdtpr-based-network-objects)
 
 Please refer the Kubernetes Network SIG - Multiple Network PoC proposal for more details refer the link - [K8s Multiple Network proposal](https://docs.google.com/document/d/1TW3P4c8auWwYy-w_5afIPDcGNLK3LZf0m14943eVfVg/edit)
-<p align="center">
-   <img src="doc/images/Vhostuser-with-multus.png" width="1008" />
-</p>
+
+![Vhostuser CNI with multus](doc/images/Vhostuser-with-multus.png)
 
 ### Configuration details
 ```

--- a/examples/crd-vhostuser-net.yaml
+++ b/examples/crd-vhostuser-net.yaml
@@ -1,0 +1,13 @@
+apiVersion: "k8s.cni.cncf.io/v1"
+kind: NetworkAttachmentDefinition
+metadata:
+  name: vhostuser-networkobj
+spec:
+  config: '{
+    "cniVersion": "0.3.0",
+    "type": "vhostuser",
+    "vhost": {
+      "vhost_tool": "/opt/cni/bin/ovs-config.py"
+    }
+  }'
+

--- a/examples/pod-multi-vhost.yaml
+++ b/examples/pod-multi-vhost.yaml
@@ -1,0 +1,31 @@
+apiVersion: v1
+kind: Pod
+metadata:
+  name: multi-vhost-example
+  annotations:
+    k8s.v1.cni.cncf.io/networks: vhostuser-networkobj, vhostuser-networkobj
+spec:
+  containers:
+  - name: multi-vhost-example
+    image: ubuntu-dpdk
+    imagePullPolicy: Never
+    securityContext:
+      privileged: true
+    volumeMounts:
+    - mountPath: /vhu/
+      name: socket
+    - mountPath: /mnt/huge
+      name: hugepage
+    resources:
+      requests:
+        memory: 1Gi
+      limits:
+        hugepages-1Gi: 1Gi
+    command: ["sleep", "infinity"]
+  volumes:
+  - name: socket
+    hostPath:
+      path: /var/lib/cni/vhostuser/
+  - name: hugepage
+    emptyDir:
+      medium: HugePages


### PR DESCRIPTION
Merge [Multiple vhostuser ports example with testpmd](https://gist.github.com/kangasta/e0050c6de9ee800ea4ac03f17177ac18) from stand alone Gist to README. This example provides guidance on how to configure simple pod with OVS as the backend.